### PR TITLE
Update build_linux.go

### DIFF
--- a/kafka/build_linux.go
+++ b/kafka/build_linux.go
@@ -2,6 +2,7 @@
 
 package kafka
 
+// #cgo pkg-config: rdkafka-static
 // #cgo CFLAGS: -I${SRCDIR}/../../../../../3rdparty/include
 // #cgo LDFLAGS: ${SRCDIR}/../../../../../3rdparty/lib/linux_amd64/librdkafka.a ${SRCDIR}/../../../../../3rdparty/lib/linux_amd64/liblz4.a ${SRCDIR}/../../../../../3rdparty/lib/linux_amd64/libsasl2.a ${SRCDIR}/../../../../../3rdparty/lib/linux_amd64/libssl.a ${SRCDIR}/../../../../../3rdparty/lib/linux_amd64/libcrypto.a -lz -lm -ldl
 //


### PR DESCRIPTION
Fix linking error for PopOS (Ubuntu 18.04).

Change copied from https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/build_static.go

Resulting file isn't completely statically linked, but works.

```
$ ldd ~/go/bin/reconciliation
        linux-vdso.so.1 (0x00007fff6ed79000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f5c935c9000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5c933c5000)
        libssl.so.1.1 => /usr/lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007f5c9315b000)
        libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f5c92ce3000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5c92ac4000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f5c928bc000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5c924cb000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5c937e6000)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peernova-private/confluent-kafka-go/1)
<!-- Reviewable:end -->
